### PR TITLE
[libossp-uuid] Initial plan and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# libossp-uuid
+
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libossp-uuid?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=164&branchName=master)
+
+OSSP uuid is a ISO-C:1999 application programming interface (API) and corresponding command line interface (CLI) for the generation of DCE 1.1
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/controls/uuid_works.rb
+++ b/controls/uuid_works.rb
@@ -1,0 +1,50 @@
+title 'Tests to confirm uuid & uuid-config binaries work as expected'
+
+base_dir = input("base_dir", value: "bin")
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input("plan_name", value: "libossp-uuid")
+plan_ident = "#{plan_origin}/#{plan_name}"
+
+control 'core-plans-libossp-uuid' do
+  impact 1.0
+  title 'Ensure uuid & uuid-config binaries are working as expected'
+  desc '
+  We first check that the binaries we expect are present and then run use / version checks to verify that they are excecutable.
+  '
+
+  hab_pkg_path = command("hab pkg path #{plan_ident}")
+  describe hab_pkg_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  target_dir = File.join(hab_pkg_path.stdout.strip, base_dir)
+
+  uuid_exists = command("ls #{File.join(target_dir, "uuid")}")
+  describe uuid_exists do
+    its('stdout') { should match /uuid/ }
+    its('stderr') { should be_empty }
+    its('exit_status') { should eq 0 }
+  end
+
+  uuid_works = command("/bin/uuid")
+  describe uuid_works do
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+    its('exit_status') { should eq 0 }
+  end
+
+  uuid_config_exists = command("ls #{File.join(target_dir, "uuid-config")}")
+  describe uuid_config_exists do
+    its('stdout') { should match /uuid-config/ }
+    its('stderr') { should be_empty }
+    its('exit_status') { should eq 0 }
+  end
+
+  uuid_config_works = command("/bin/uuid-config --version")
+  describe uuid_config_works do
+    its('stdout') { should match /OSSP uuid [0-9]+.[0-9]+.[0-9]+/ }
+    its('stderr') { should be_empty }
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: libossp-uuid
+title: Habitat Core Plan libossp-uuid
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan libossp-uuid
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,16 @@
+pkg_name=libossp-uuid
+_pkg_distname=uuid
+pkg_origin=core
+pkg_description="OSSP uuid is a ISO-C:1999 application programming interface (API) and corresponding command line interface (CLI) for the generation of DCE 1.1"
+pkg_upstream_url="http://www.ossp.org/pkg/lib/uuid/"
+pkg_version=1.6.2
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('MIT')
+pkg_source=https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/${_pkg_distname}/${_pkg_distname}-${pkg_version}.tar.gz
+pkg_shasum=11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/coreutils core/make core/gcc core/binutils)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+pkg_dirname=${_pkg_distname}-${pkg_version}


### PR DESCRIPTION
Profile: Habitat Core Plan libossp-uuid (libossp-uuid)
Version: 0.1.0
Target:  docker://edcdd168c98372db5283db8fd7e46f9d95f507d7980b3fdc01e9cfcfce52a0b5

  ✔  core-plans-libossp-uuid: Ensure uuid & uuid-config binaries are working as expected
     ✔  Command: `hab pkg path mindnumbing/libossp-uuid` exit_status is expected to eq 0
     ✔  Command: `hab pkg path mindnumbing/libossp-uuid` stdout is expected not to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libossp-uuid/1.6.2/20200610102118/bin/uuid` stdout is expected to match /uuid/
     ✔  Command: `ls /hab/pkgs/mindnumbing/libossp-uuid/1.6.2/20200610102118/bin/uuid` stderr is expected to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libossp-uuid/1.6.2/20200610102118/bin/uuid` exit_status is expected to eq 0
     ✔  Command: `/bin/uuid` stdout is expected not to be empty
     ✔  Command: `/bin/uuid` stderr is expected to be empty
     ✔  Command: `/bin/uuid` exit_status is expected to eq 0
     ✔  Command: `ls /hab/pkgs/mindnumbing/libossp-uuid/1.6.2/20200610102118/bin/uuid-config` stdout is expected to match /uuid-config/
     ✔  Command: `ls /hab/pkgs/mindnumbing/libossp-uuid/1.6.2/20200610102118/bin/uuid-config` stderr is expected to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libossp-uuid/1.6.2/20200610102118/bin/uuid-config` exit_status is expected to eq 0
     ✔  Command: `/bin/uuid-config --version` stdout is expected to match /OSSP uuid [0-9]+.[0-9]+.[0-9]+/
     ✔  Command: `/bin/uuid-config --version` stderr is expected to be empty
     ✔  Command: `/bin/uuid-config --version` exit_status is expected to eq 0


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 14 successful, 0 failures, 0 skipped

Signed-off-by: Steven Marshall <SMarshall@chef.io>